### PR TITLE
✨ Feature/timeframe zoom

### DIFF
--- a/user_data/strategies/MoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MoniGoManiHyperStrategy.py
@@ -6,7 +6,6 @@ from pandas import DataFrame
 import pandas as pd
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.strategy import IStrategy, CategoricalParameter, IntParameter, merge_informative_pair, timeframe_to_minutes
-from datetime import datetime, timedelta
 # ^ TA-Lib Autofill mostly broken in JetBrains Products,
 # ta._ta_lib.<function_name> can temporarily be used while writing as a workaround
 # Then change back to ta.<function_name> so IDE won't nag about accessing a protected member of TA-Lib
@@ -147,7 +146,9 @@ class MoniGoManiHyperStrategy(IStrategy):
     ####################################################################################################################
 
     # Optimal timeframe for the strategy.
+    # easy switching between backtesting and live/dry run, just remove _
     timeframe = '1h'
+    _timeframe = '5m'
     informative_timeframe = "1h"
 
     # Run "populate_indicators()" only for new candle.
@@ -534,15 +535,6 @@ class MoniGoManiHyperStrategy(IStrategy):
         dataframe.loc[(dataframe['adx'] > 20) & (dataframe['plus_di'] > dataframe['minus_di']), 'trend'] = 'upwards'
 
         return dataframe
-
-    def round_time_down_to_nearest(self, time: pd.Timestamp, time_in_minutes: int) -> datetime:
-        """
-        Round a time to the nearest minutes. e.g. time=08:21 time_in_minutes=15 converts to 08:15.
-        """
-        # convert to datetime then round down. Seconds will be 0, but include anyway.
-        time = datetime(time.year, time.month, time.day, time.hour, time.minute, time.second)
-        time = time - (time - time.min) % timedelta(minutes=time_in_minutes)
-        return pd.to_datetime(time)
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """

--- a/user_data/strategies/MoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MoniGoManiHyperStrategy.py
@@ -450,7 +450,8 @@ class MoniGoManiHyperStrategy(IStrategy):
 
     def _populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
-        Adds several different TA indicators to the given DataFrame
+        Actually adds several different TA indicators to the given DataFrame. 
+        Should be called with 1h informative pair in backtesting.
 
         Performance Note: For the best performance be frugal on the number of indicators
         you are using. Let uncomment only the indicator you are using in your strategies
@@ -538,6 +539,9 @@ class MoniGoManiHyperStrategy(IStrategy):
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
+        Adds indicators based on run mode. If backtesting it pulls 1h informative pairs to compute
+        indicators, but then tests on 1-5m timeframe. If live/dry use 1h either way.
+
         :param dataframe: Dataframe with data from the exchange
         :param metadata: Additional information, like the currently traded pair
         :return: a Dataframe with all mandatory indicators for the strategies

--- a/user_data/strategies/MoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MoniGoManiHyperStrategy.py
@@ -161,7 +161,8 @@ class MoniGoManiHyperStrategy(IStrategy):
 
     # Number of candles the strategy requires before producing valid signals
     # in live and dry runs this ratio will be 1, so nothing changes there.
-    # But we need `startup_candle_count` to be for the timeframe of `informative_timeframe` (1h) not `timeframe` (5m)
+    # But we need `startup_candle_count` to be for the timeframe of 
+    # `informative_timeframe` (1h) not `timeframe` (5m) for backtesting.
     startup_candle_count: int = 400 * int(timeframe_to_minutes(informative_timeframe) / timeframe_to_minutes(timeframe))
     # SMA200 needs 200 candles before producing valid signals
     # EMA200 needs an extra 200 candles of SMA200 before producing valid signals

--- a/user_data/strategies/MoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MoniGoManiHyperStrategy.py
@@ -146,9 +146,8 @@ class MoniGoManiHyperStrategy(IStrategy):
     ####################################################################################################################
 
     # Optimal timeframe for the strategy.
-    # easy switching between backtesting and live/dry run, just remove _
     timeframe = '1h'
-    _timeframe = '5m'
+    backtest_timeframe = "5m"
     informative_timeframe = "1h"
 
     # Run "populate_indicators()" only for new candle.
@@ -434,6 +433,12 @@ class MoniGoManiHyperStrategy(IStrategy):
     #     def stoploss_space():
     #         return [RealParameter(-0.01, -0.35, name='stoploss')]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if (self.dp is not None) & (self.dp.runmode.value in ('backtest', 'hyperopt')):
+            self.timeframe = self.backtest_timeframe
+            print(f"Auto updating timeframe to {self.timeframe}")
+
     def informative_pairs(self):
         """
         Define additional, informative pair/interval combinations to be cached from the exchange.
@@ -548,7 +553,7 @@ class MoniGoManiHyperStrategy(IStrategy):
         :return: a Dataframe with all mandatory indicators for the strategies
         """
         # Check which mode we are in.
-        if self.config['runmode'].value in ('backtest', 'hyperopt'):
+        if (self.dp is not None) & (self.dp.runmode.value in ('backtest', 'hyperopt')):
             assert (timeframe_to_minutes(self.timeframe) <= 5), "Backtest this strategy in 5m or 1m timeframe."
 
             if not self.dp:

--- a/user_data/strategies/MoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MoniGoManiHyperStrategy.py
@@ -435,7 +435,7 @@ class MoniGoManiHyperStrategy(IStrategy):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if (self.dp is not None) & (self.dp.runmode.value in ('backtest', 'hyperopt')):
+        if (self.dp is not None) and (self.dp.runmode.value in ('backtest', 'hyperopt')):
             self.timeframe = self.backtest_timeframe
             print(f"Auto updating timeframe to {self.timeframe}")
 
@@ -553,7 +553,7 @@ class MoniGoManiHyperStrategy(IStrategy):
         :return: a Dataframe with all mandatory indicators for the strategies
         """
         # Check which mode we are in.
-        if (self.dp is not None) & (self.dp.runmode.value in ('backtest', 'hyperopt')):
+        if (self.dp is not None) and (self.dp.runmode.value in ('backtest', 'hyperopt')):
             assert (timeframe_to_minutes(self.timeframe) <= 5), "Backtest this strategy in 5m or 1m timeframe."
 
             if not self.dp:


### PR DESCRIPTION
This PR adds a timeframe zoom feature. When backtesting it will check that you are using 1 or 5m timeframe and throws an error if otherwise. It's a bit annoying to change all the time but I don't think there is a good solution to do it automatically (without a bunch of overhead when running live). It also makes sure that you don't forget to change it back and start running the strat live at 5m.

This is pretty much ripped off of Obelisk with a few small improvements.

- Automatic `startup_candle_count` conversion when backtesting
- filtering out informative pair data from before the start date of backtesting

Here are some backtesting results using v0.8.1 weights and original coin list:

```
    Backtesting with 1h candles                             Backtesting with 5m candles                         Backtesting with 1m candles
    and 1h indicators                                       and 1h indicators                                   and 1h indicators

=============== SUMMARY METRICS ===============    =============== SUMMARY METRICS ===============    =============== SUMMARY METRICS ===============
| Metric                | Value               |    | Metric                | Value               |    | Metric                | Value               |
|-----------------------+---------------------|    |-----------------------+---------------------|    |-----------------------+---------------------|
| Backtesting from      | 2021-03-16 00:00:00 |    | Backtesting from      | 2021-03-16 00:00:00 |    | Backtesting from      | 2021-03-16 00:00:00 |
| Backtesting to        | 2021-04-12 18:00:00 |    | Backtesting to        | 2021-04-12 20:05:00 |    | Backtesting to        | 2021-04-12 20:15:00 |
| Max open trades       | 15                  |    | Max open trades       | 15                  |    | Max open trades       | 15                  |
|                       |                     |    |                       |                     |    |                       |                     |
| Total trades          | 519                 |    | Total trades          | 543                 |    | Total trades          | 557                 |
| Starting balance      | 0.03000000 BTC      |    | Starting balance      | 0.03000000 BTC      |    | Starting balance      | 0.03000000 BTC      |
| Final balance         | 0.03439923 BTC      |    | Final balance         | 0.03122258 BTC      |    | Final balance         | 0.03177557 BTC      |
| Absolute profit       | 0.00439923 BTC      |    | Absolute profit       | 0.00122258 BTC      |    | Absolute profit       | 0.00177557 BTC      |
| Total profit %        | 14.66%              |    | Total profit %        | 4.08%               |    | Total profit %        | 5.92%               |
| Trades per day        | 19.22               |    | Trades per day        | 20.11               |    | Trades per day        | 20.63               |
| Avg. stake amount     | 0.00100000 BTC      |    | Avg. stake amount     | 0.00100000 BTC      |    | Avg. stake amount     | 0.00100000 BTC      |
| Total trade volume    | 0.51900000 BTC      |    | Total trade volume    | 0.54300000 BTC      |    | Total trade volume    | 0.55700000 BTC      |
|                       |                     |    |                       |                     |    |                       |                     |
| Best Pair             | XRP/BTC 117.26%     |    | Best Pair             | XRP/BTC 52.1%       |    | Best Pair             | XRP/BTC 47.27%      |
| Worst Pair            | ATOM/BTC -7.2%      |    | Worst Pair            | ATOM/BTC -14.56%    |    | Worst Pair            | ALGO/BTC -10.52%    |
| Best trade            | BAT/BTC 14.53%      |    | Best trade            | IOTA/BTC 11.82%     |    | Best trade            | IOTA/BTC 11.82%     |
| Worst trade           | BAT/BTC -16.7%      |    | Worst trade           | BAT/BTC -16.7%      |    | Worst trade           | BAT/BTC -16.7%      |
| Best day              | 0.00118662 BTC      |    | Best day              | 0.00077558 BTC      |    | Best day              | 0.00083949 BTC      |
| Worst day             | -0.00058256 BTC     |    | Worst day             | -0.00069658 BTC     |    | Worst day             | -0.00068235 BTC     |
| Days win/draw/lose    | 18 / 0 / 10         |    | Days win/draw/lose    | 17 / 0 / 11         |    | Days win/draw/lose    | 18 / 0 / 10         |
| Avg. Duration Winners | 7:02:00             |    | Avg. Duration Winners | 7:31:00             |    | Avg. Duration Winners | 7:18:00             |
| Avg. Duration Loser   | 21:35:00            |    | Avg. Duration Loser   | 22:17:00            |    | Avg. Duration Loser   | 22:03:00            |
|                       |                     |    |                       |                     |    |                       |                     |
| Min balance           | 0.03002119 BTC      |    | Min balance           | 0.03001877 BTC      |    | Min balance           | 0.03002380 BTC      |
| Max balance           | 0.03502614 BTC      |    | Max balance           | 0.03228575 BTC      |    | Max balance           | 0.03272172 BTC      |
| Drawdown              | 63.05%              |    | Drawdown              | 106.67%             |    | Drawdown              | 94.52%              |
| Drawdown              | 0.00063117 BTC      |    | Drawdown              | 0.00106771 BTC      |    | Drawdown              | 0.00094615 BTC      |
| Drawdown high         | 0.00182573 BTC      |    | Drawdown high         | 0.00228575 BTC      |    | Drawdown high         | 0.00272172 BTC      |
| Drawdown low          | 0.00119456 BTC      |    | Drawdown low          | 0.00121804 BTC      |    | Drawdown low          | 0.00177557 BTC      |
| Drawdown Start        | 2021-03-18 03:00:00 |    | Drawdown Start        | 2021-04-07 05:50:00 |    | Drawdown Start        | 2021-04-07 05:54:00 |
| Drawdown End          | 2021-03-19 18:00:00 |    | Drawdown End          | 2021-04-12 20:05:00 |    | Drawdown End          | 2021-04-12 20:15:00 |
| Market change         | 36.19%              |    | Market change         | 49.78%              |    | Market change         | 45.3%               |
===============================================    ===============================================    ===============================================
```

Running a hyperopt with this new feature gives less tight results for trailing stoploss:
```
trailing_stop = True
trailing_stop_positive = 0.2886
trailing_stop_positive_offset = 0.30253
trailing_only_offset_is_reached = False
```