### PR TITLE
🐞 Prevent docker-compose.yml from throwing errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     # Use plotting image
     # image: freqtradeorg/freqtrade:develop_plot
     # Build step - only needed when additional dependencies are needed
-    build:
-      context: .
-      dockerfile: "./docker/Dockerfile.technical"
+    #build:
+    #  context: .
+    #  dockerfile: "./docker/Dockerfile.technical"
     restart: unless-stopped
     container_name: Freqtrade-MoniGoMani
     volumes:


### PR DESCRIPTION
1) There is no reason for a service defined in a docker-compose file to reference both a public "image" on Dockerhub and have at the same time a "build:" section
2) The build section, just by itself, throws error during the image building process (the docker/Dockerfile.technical file issues 'apt-get' commands which are not successful)
3) As a starting point for new users, the freqtradeorg Dockerhub image is just fine to use