### PR TITLE
⚡️ Updated Config default  tradable balance ratio to account for fees

### DIFF
--- a/user_data/mgm-config.json
+++ b/user_data/mgm-config.json
@@ -27,7 +27,7 @@
     "max_open_trades": -1,
     "stake_currency": "USDT",
     "stake_amount": 45,
-    "tradable_balance_ratio": 1.00,
+    "tradable_balance_ratio": 0.99,
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,


### PR DESCRIPTION
Set the default  **tradable_balance_ratio** to `0.99` to keep a minimum balance for eventual fees.