### PR TITLE
🐞 Fixes error when running "docker-compose build"

### DIFF
--- a/docker/Dockerfile.MoniGoMani
+++ b/docker/Dockerfile.MoniGoMani
@@ -7,6 +7,6 @@ USER root
 RUN apt-get install -y jq
 
 # Copy Rikj000's version of hyperopt_tools.py to use it instead of the freqtrades current one.
-COPY ../user_data/mgm_tools/hyperopt_tools.py freqtrade/optimize/hyperopt_tools.py
+COPY ./user_data/mgm_tools/hyperopt_tools.py freqtrade/optimize/hyperopt_tools.py
 
 USER ftuser


### PR DESCRIPTION
fixes error when running `docker-compose build`

Error:
```
Step 4/5 : COPY ../user_data/mgm_tools/hyperopt_tools.py freqtrade/optimize/hyperopt_tools.py
COPY failed: forbidden path outside the build context: ../user_data/mgm_tools/hyperopt_tools.py ()
ERROR: Service 'freqtrade' failed to build : Build failed
``` 
