### PR TITLE
✨ feat(mgm-tools): kraken support in data downloader script, parallelism support

### DIFF
--- a/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
+++ b/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
@@ -13,7 +13,7 @@ TMP_DIR="/tmp"
 # define one ore more quotecoins as array (USDT ETH BTC)
 # QUOTECOINS=(USDT ETH BTC)
 ###
-EXCHANGES=(binance bitpanda coinex)
+EXCHANGES=(binance bitpanda coinex kraken)
 QUOTECOINS=(ETH)
 
 ###
@@ -22,6 +22,21 @@ QUOTECOINS=(ETH)
 ###
 TIMEFRAMES="5m 1h"
 DAYS=1
+
+
+###
+# Parallel downloads - This, for now, is Kraken-only
+# if you would like to tweak parallel downloads for Kraken, set this appropriately
+# they rate limit by IP & quote pair, so even though they're quite aggressive on rate limits
+# doing this in parallel by pair doesn't get rate limited IME, by default, one process per core
+# since Kraken requires that the trade data is downloaded to generate candles > 720 but nprocs *2
+# or even more parallelism is probably just fine on architectures like x64 with SMT, etc
+#
+# I have added this with a bit of thought towards allowing by-exchange parallelism if other exchanges
+# have similar rate limiting, but this is outside my experience with other exchanges right now
+###
+PARALLEL_REQS_KRAKEN=`nproc`
+PARALLEL_REQS_DEFAULT=1
 
 ### PID FILE CHECK NOT TO START ANOTHER DOWNLOAD ######################################################################
 PIDFILE=/var/run/fqtpairdownload.pid
@@ -61,6 +76,14 @@ source .env/bin/activate ;
 # loop through exchanges
 for EXCHANGE in ${EXCHANGES[@]}
 do
+  # Kraken is odd, you need to dl-trades (see freqtrade's discussion on this in their download-data docs), check for this extra opt
+  if [[ ${EXCHANGE,,} == *"kraken"* ]]
+  then
+    EXCHG_SPECIFIC_OPTS="--dl-trades"
+    PARALLEL_REQS=${PARALLEL_REQS_KRAKEN}
+  else
+    PARALLEL_REQS=$PARALLEL_REQS_DEFAULT
+  fi
   # loop through quote coins
   for COIN in ${QUOTECOINS[@]}
   do
@@ -77,7 +100,7 @@ do
       echo "exchange ${EXCHANGE} has currently ${PAIR_COUNT} pairs for ${COIN} - starting download for timeframes = ${TIMEFRAMES}, days = ${DAYS}"
       START=$(date +%s)
       # >>> main magic! :)
-      freqtrade download-data --pairs-file ${TMP_FILE} --days ${DAYS} --timeframes ${TIMEFRAMES} --exchange ${EXCHANGE} --logfile ${LOG_FILE} 2>/dev/null
+      jq -c -r '.[]' ${TMP_FILE} | parallel -j${PARALLEL_REQS} freqtrade download-data ${EXCHG_SPECIFIC_OPTS} --days ${DAYS} --timeframes ${TIMEFRAMES} --exchange ${EXCHANGE} --logfile ${LOG_FILE} --pairs {} 2>/dev/null
       END=$(date +%s)
       DIFF=$(echo "${END} - ${START}" | bc)
       echo "exchange ${EXCHANGE} pair download for ${COIN} completed in ${DIFF}s"

--- a/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
+++ b/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
@@ -23,7 +23,6 @@ QUOTECOINS=(ETH)
 TIMEFRAMES="5m 1h"
 DAYS=1
 
-
 ###
 # Parallel downloads - This, for now, is Kraken-only
 # if you would like to tweak parallel downloads for Kraken, set this appropriately
@@ -37,9 +36,17 @@ DAYS=1
 ###
 PARALLEL_REQS_KRAKEN=`nproc`
 PARALLEL_REQS_DEFAULT=1
+PARALLEL_INSTALLED=1
+if ! command -v parallel &> /dev/null
+then
+    PARALLEL_INSTALLED=0
+    echo "GNU Parallel doesn't appear to be installed or in the PATH, parallel downloads will not be used"
+    echo "Install GNU parallel (https://www.gnu.org/software/parallel/) to utilize parallel downloads when supported"
+fi
+
 
 ### PID FILE CHECK NOT TO START ANOTHER DOWNLOAD ######################################################################
-PIDFILE=/var/run/fqtpairdownload.pid
+PIDFILE=/var/run/fqtpairdownloadeur.pid
 
 if [ -f $PIDFILE ]
 then
@@ -84,6 +91,14 @@ do
   else
     PARALLEL_REQS=$PARALLEL_REQS_DEFAULT
   fi
+  
+  if [[ PARALLEL_REQS -gt 1  && PARALLEL_INSTALLED == 0 ]] 
+  then
+        echo "You have asked for $PARALLEL_REQS parallel downloads, but GNU Parallel doesn't appear to be installed"
+        echo "or is not in the PATH, parallel downloads will not be used until this is fixed."
+        echo "Install GNU parallel and ensure it is in the PATH (https://www.gnu.org/software/parallel/) to utilize parallel downloads when supported"
+        PARALLEL_REQS=1
+  fi
   # loop through quote coins
   for COIN in ${QUOTECOINS[@]}
   do
@@ -100,7 +115,12 @@ do
       echo "exchange ${EXCHANGE} has currently ${PAIR_COUNT} pairs for ${COIN} - starting download for timeframes = ${TIMEFRAMES}, days = ${DAYS}"
       START=$(date +%s)
       # >>> main magic! :)
-      jq -c -r '.[]' ${TMP_FILE} | parallel -j${PARALLEL_REQS} freqtrade download-data ${EXCHG_SPECIFIC_OPTS} --days ${DAYS} --timeframes ${TIMEFRAMES} --exchange ${EXCHANGE} --logfile ${LOG_FILE} --pairs {} 2>/dev/null
+      if [[ ${PARALLEL_INSTALLED} == 1 ]]
+      then
+        jq -c -r '.[]' ${TMP_FILE} | parallel -j${PARALLEL_REQS} freqtrade download-data ${EXCHG_SPECIFIC_OPTS} --days ${DAYS} --timeframes ${TIMEFRAMES} --exchange ${EXCHANGE} --logfile ${LOG_FILE} --pairs {} 2>/dev/null
+      else
+        freqtrade download-data ${EXCHG_SPECIFIC_OPTS} --days ${DAYS} --timeframes ${TIMEFRAMES} --exchange ${EXCHANGE} --logfile ${LOG_FILE} --pair-file ${TMP_FILE}
+      fi
       END=$(date +%s)
       DIFF=$(echo "${END} - ${START}" | bc)
       echo "exchange ${EXCHANGE} pair download for ${COIN} completed in ${DIFF}s"


### PR DESCRIPTION
This PR adds support for Kraken to the data downloader script and parallelizes downloads from Kraken because of the allowance in the rate limiting system they have on the API that rate limits by IP/Currency pairs. 

Parallel downloads require GNU parallel to be installed and in the PATH, but to avoid unnecessarily bloating dependencies, it will only allow parallel downloads if `parallel` is installed and successfully executable (it checks for this and fails back to serial downloads if not). 

Specifically:

1. Kraken is odd about data history APIs (see https://www.freqtrade.io/en/stable/exchanges/#historic-kraken-data), they offer trade data, but only 720 candles, and regardless of timeframe, they keep returning the same 720, so the workaround is to use --dl-trades and resample into candles. So added a EXCHG_SPECIFIC_OPTS var to handle this for Kraken-only if kraken is the exchange in the loop iteration.
2. Kraken also, less oddly, applies rate limits by IP and Pair, so I have added support for parallel downloads for Kraken which currently sets default to the number of cores of the machine but is configurable via PARALLEL_REQS_KRAKEN

I am a new freqtrade/mgm user and this is my first contribution back, so if I am missing something in terms of process, tests, or wisdom about this PR, please let me know so I can learn the system here. I wasn't able to find contributor guidelines, so this is my best attempt at this small enhancement, but if there are things needed to improve this or standardize with MGM style, please let me know. 
