### PR TITLE
⚡️ fix(hyperopt): fail gracefully on bad hyperopt json

### DIFF
--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -133,10 +133,15 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
     # If results from a previous HyperOpt Run are found then continue the next HyperOpt Run upon them
     mgm_config_hyperopt_path = f'{os.getcwd()}/user_data/{mgm_config_hyperopt_name}'
     if os.path.isfile(mgm_config_hyperopt_path) is True:
-        # Load the previous 'mgm-config-hyperopt.json' file as an object and parse it as a dictionary
-        file_object = open(mgm_config_hyperopt_path, )
-        mgm_config_hyperopt = json.load(file_object)
-
+        # Try to load the previous 'mgm-config-hyperopt.json' file as an object and parse it as a dictionary
+        # if the parse fails, warn and continue as if it didn't exist.
+        try:
+            file_object = open(mgm_config_hyperopt_path, )
+            mgm_config_hyperopt = json.load(file_object)
+          except ValueError as e:
+              mgm_config_hyperopt = {}
+              logger.warn(f'MoniGoManiHyperStrategy - WARN - {mgm_config_hyperopt_path} is inaccessible or is not valid JSON'
+                          f'Disregarding existing file and treating as first hyperopt run')
         # Convert the loaded 'mgm-config-hyperopt.json' data to the needed HyperOpt Results format if it's found
         # Default stub values from 'mgm-config.json' are used otherwise.
         for space in mgm_config_hyperopt['params']:

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -140,8 +140,9 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             mgm_config_hyperopt = json.load(file_object)
           except ValueError as e:
               mgm_config_hyperopt = {}
-              logger.warn(f'MoniGoManiHyperStrategy - WARN - {mgm_config_hyperopt_path} is inaccessible or is not valid JSON'
-                          f'Disregarding existing file and treating as first hyperopt run')
+              logger.warn(f'MoniGoManiHyperStrategy - WARN - {mgm_config_hyperopt_path} is inaccessible or is not valid JSON,'
+                          f'disregarding existing {mgm_config_hyperopt_name} file and treating as first hyperopt run!')
+
         # Convert the loaded 'mgm-config-hyperopt.json' data to the needed HyperOpt Results format if it's found
         # Default stub values from 'mgm-config.json' are used otherwise.
         for space in mgm_config_hyperopt['params']:


### PR DESCRIPTION
This PR adds a check when loading a mgm-config-hyperopt.json file. 

I experienced a situation where I specified (accidentally) an invalid epoch number and this generated a zero-length file in mgm-config-hyperopt.json because the documentation's command to generate this from the hyperopt run uses shell pipes, so an error in an earlier command will result in an empty mgm-config-hyperopt.json file, which in turn causes MGM's loading code to see the file and take the "let's parse it" code path, but the parse error results in an error. 

This simply handles any such error (be it the one I had or a permissions issue or a hand-edited file that is now invalid JSON, etc), warns the user, and continues the logic on the "like it never existed" code path. 