### PR TITLE
🐞 BugFix `startup_candle_count`

### DIFF
--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -344,14 +344,12 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
                                                     f'Auto updated is_dry_live_run_detected to: False')
 
             self.mgm_logger('info', initialization,
-                            f'Calculating and storing "timeframe_multiplier" + Updating startup_candle_count"')
+                            f'Calculating and storing "timeframe_multiplier"')
             self.timeframe_multiplier = \
                 int(timeframe_to_minutes(self.informative_timeframe) / timeframe_to_minutes(self.timeframe))
             if self.timeframe_multiplier < 1:
                 raise SystemExit(f'MoniGoManiHyperStrategy - ERROR - TimeFrame-Zoom - "timeframe" must be bigger than '
                                  f'"backtest_timeframe"')
-            if RunMode(config.get('runmode', RunMode.OTHER)) is RunMode.BACKTEST:
-                self.startup_candle_count *= self.timeframe_multiplier
 
         else:
             if os.path.isfile(self.mgm_config_hyperopt_path) is False:

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -16,6 +16,7 @@ from numpy import timedelta64
 from pandas import DataFrame
 from scipy.interpolate import interp1d
 
+from freqtrade.data.history import load_pair_history
 from freqtrade.enums import RunMode
 from freqtrade.exchange import timeframe_to_prev_date
 from freqtrade.misc import deep_merge_dicts, round_dict
@@ -343,8 +344,7 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             self.mgm_logger('info', initialization, f'Current run mode detected as: HyperOpting/BackTesting. '
                                                     f'Auto updated is_dry_live_run_detected to: False')
 
-            self.mgm_logger('info', initialization,
-                            f'Calculating and storing "timeframe_multiplier"')
+            self.mgm_logger('info', initialization, f'Calculating and storing "timeframe_multiplier"')
             self.timeframe_multiplier = \
                 int(timeframe_to_minutes(self.informative_timeframe) / timeframe_to_minutes(self.timeframe))
             if self.timeframe_multiplier < 1:
@@ -468,9 +468,13 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
                                                     f'informative_timeframe ({self.informative_timeframe} candles) and '
                                                     f'a zoomed backtest_timeframe ({self.backtest_timeframe} candles)')
 
-            # Warning! This method gets ALL downloaded data that you have (when in backtesting mode).
+            # Warning! This method gets ALL downloaded data for the given timeframe (when in BackTesting mode).
             # If you have many months or years downloaded for this pair, this will take a long time!
-            informative = self.dp.get_pair_dataframe(pair=metadata['pair'], timeframe=self.informative_timeframe)
+            informative = load_pair_history(pair=metadata['pair'],
+                                            datadir=self.config['datadir'],
+                                            timeframe=self.informative_timeframe,
+                                            startup_candles=self.startup_candle_count,
+                                            data_format=self.config.get('dataformat_ohlcv', 'json'))
 
             # Throw away older data that isn't needed.
             first_informative = dataframe['date'].min().floor('H')

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -350,7 +350,8 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             if self.timeframe_multiplier < 1:
                 raise SystemExit(f'MoniGoManiHyperStrategy - ERROR - TimeFrame-Zoom - "timeframe" must be bigger than '
                                  f'"backtest_timeframe"')
-            self.startup_candle_count *= self.timeframe_multiplier
+            if RunMode(config.get('runmode', RunMode.OTHER)) is RunMode.BACKTEST:
+                self.startup_candle_count *= self.timeframe_multiplier
 
         else:
             if os.path.isfile(self.mgm_config_hyperopt_path) is False:


### PR DESCRIPTION
Fixes #91 

Set actual startup_candle_count only in BACKTEST mode. Probably even in BACKTEST mode it should not be set?

Either way, this patch solves the current HO issue with most recent freqtrade-version (develop).