### PR TITLE
✨ Allow config difference core trend timeframe

### DIFF
--- a/user_data/mgm-config.example.json
+++ b/user_data/mgm-config.example.json
@@ -1,7 +1,7 @@
 {
   "monigomani_settings": {
     "timeframe": "30m",
-    "trend_timeframe": "1d",
+    "trend_timeframe": "4h",
     "backtest_timeframe": "5m",
     "startup_candle_count": 400,
     "precision": 1,

--- a/user_data/mgm-config.example.json
+++ b/user_data/mgm-config.example.json
@@ -1,6 +1,7 @@
 {
   "monigomani_settings": {
     "timeframe": "30m",
+    "trend_timeframe": "1d",
     "backtest_timeframe": "5m",
     "startup_candle_count": 400,
     "precision": 1,

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -488,13 +488,13 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             informative = merge_informative_pair(
                 informative, core_trend[['date', 'ht_trendmode', 'sar', 'trend']].copy(),
                 self.informative_timeframe, self.core_trend_timeframe, ffill=True)
-            informative['ht_trendmode'] = informative['ht_trendmode_' + self.core_trend_timeframe]
-            informative['sar'] = informative['sar_' + self.core_trend_timeframe]
-            informative['trend'] = informative['trend_' + self.core_trend_timeframe]
-            del informative['date_' + self.core_trend_timeframe]
-            del informative['ht_trendmode_' + self.core_trend_timeframe]
-            del informative['sar_' + self.core_trend_timeframe]
-            del informative['trend_' + self.core_trend_timeframe]
+            informative['ht_trendmode'] = informative[f'ht_trendmode_{self.core_trend_timeframe}']
+            informative['sar'] = informative[f'sar_{self.core_trend_timeframe}']
+            informative['trend'] = informative[f'trend_{self.core_trend_timeframe}']
+            del informative[f'date_{self.core_trend_timeframe}']
+            del informative[f'ht_trendmode_{self.core_trend_timeframe}']
+            del informative[f'sar_{self.core_trend_timeframe}']
+            del informative[f'trend_{self.core_trend_timeframe}']
 
             # Populate indicators at a larger timeframe
             informative = self.do_populate_indicators(informative.copy(), metadata)
@@ -517,15 +517,15 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             dataframe = merge_informative_pair(
                 dataframe, core_trend[['date', 'ht_trendmode', 'sar', 'trend', 'mgm_trend']].copy(), 
                 self.timeframe, self.core_trend_timeframe, ffill=True)
-            dataframe['ht_trendmode'] = dataframe['ht_trendmode_' + self.core_trend_timeframe]
-            dataframe['sar'] = dataframe['sar_' + self.core_trend_timeframe]
-            dataframe['trend'] = dataframe['trend_' + self.core_trend_timeframe]
-            dataframe['mgm_trend'] = dataframe['mgm_trend_' + self.core_trend_timeframe]
-            del dataframe['date_' + self.core_trend_timeframe]
-            del dataframe['ht_trendmode_' + self.core_trend_timeframe]
-            del dataframe['sar_' + self.core_trend_timeframe]
-            del dataframe['trend_' + self.core_trend_timeframe]
-            del dataframe['mgm_trend_' + self.core_trend_timeframe]
+            dataframe['ht_trendmode'] = dataframe[f'ht_trendmode_{self.core_trend_timeframe}']
+            dataframe['sar'] = dataframe[f'sar_{self.core_trend_timeframe}']
+            dataframe['trend'] = dataframe[f'trend_{self.core_trend_timeframe}']
+            dataframe['mgm_trend'] = dataframe[f'mgm_trend_{self.core_trend_timeframe}']
+            del dataframe[f'date_{self.core_trend_timeframe}']
+            del dataframe[f'ht_trendmode_{self.core_trend_timeframe}']
+            del dataframe[f'sar_{self.core_trend_timeframe}']
+            del dataframe[f'trend_{self.core_trend_timeframe}']
+            del dataframe[f'mgm_trend_{self.core_trend_timeframe}']
 
             # Just populate indicators.
             dataframe = self.do_populate_indicators(dataframe, metadata)

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -461,11 +461,11 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
         tfz = 'TimeFrame-Zoom'
         # Populate core trend indicators
         core_trend = load_pair_history(pair=metadata['pair'],
-                                        datadir=self.config['datadir'],
-                                        timeframe=self.core_trend_timeframe,
-                                        # ToDo: calculate correct startup_candles needed for HT_TRENDMODE and SAR
-                                        startup_candles=self.startup_candle_count,
-                                        data_format=self.config.get('dataformat_ohlcv', 'json'))
+                                       datadir=self.config['datadir'],
+                                       timeframe=self.core_trend_timeframe,
+                                       # ToDo: calculate correct startup_candles needed for HT_TRENDMODE and SAR
+                                       startup_candles=self.startup_candle_count,
+                                       data_format=self.config.get('dataformat_ohlcv', 'json'))
         core_trend = self._populate_core_trend(core_trend, metadata)
 
         # Compute indicator data during Backtesting / Hyperopting when TimeFrame-Zooming

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -463,7 +463,8 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
         core_trend = load_pair_history(pair=metadata['pair'],
                                         datadir=self.config['datadir'],
                                         timeframe=self.core_trend_timeframe,
-                                        startup_candles=200, # ToDo: calculate correct startup_candles needed for HT_TRENDMODE and SAR
+                                        # ToDo: calculate correct startup_candles needed for HT_TRENDMODE and SAR
+                                        startup_candles=self.startup_candle_count,
                                         data_format=self.config.get('dataformat_ohlcv', 'json'))
         core_trend = self._populate_core_trend(core_trend, metadata)
 

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -489,13 +489,10 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
             informative = merge_informative_pair(
                 informative, core_trend[['date', 'ht_trendmode', 'sar', 'trend']].copy(),
                 self.informative_timeframe, self.core_trend_timeframe, ffill=True)
-            informative['ht_trendmode'] = informative[f'ht_trendmode_{self.core_trend_timeframe}']
-            informative['sar'] = informative[f'sar_{self.core_trend_timeframe}']
-            informative['trend'] = informative[f'trend_{self.core_trend_timeframe}']
-            del informative[f'date_{self.core_trend_timeframe}']
-            del informative[f'ht_trendmode_{self.core_trend_timeframe}']
-            del informative[f'sar_{self.core_trend_timeframe}']
-            del informative[f'trend_{self.core_trend_timeframe}']
+            skip_columns = [f'{s}_{self.core_trend_timeframe}' for s in
+                            ['date', 'open', 'high', 'low', 'close', 'volume']]
+            informative.rename(columns=lambda s: s.replace('_{}'.format(self.core_trend_timeframe),
+                                                           '') if (s not in skip_columns) else s, inplace=True)
 
             # Populate indicators at a larger timeframe
             informative = self.do_populate_indicators(informative.copy(), metadata)
@@ -516,17 +513,12 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
 
             # Merge core trend to main data frame
             dataframe = merge_informative_pair(
-                dataframe, core_trend[['date', 'ht_trendmode', 'sar', 'trend', 'mgm_trend']].copy(), 
+                dataframe, core_trend[['date', 'ht_trendmode', 'sar', 'trend', 'mgm_trend']].copy(),
                 self.timeframe, self.core_trend_timeframe, ffill=True)
-            dataframe['ht_trendmode'] = dataframe[f'ht_trendmode_{self.core_trend_timeframe}']
-            dataframe['sar'] = dataframe[f'sar_{self.core_trend_timeframe}']
-            dataframe['trend'] = dataframe[f'trend_{self.core_trend_timeframe}']
-            dataframe['mgm_trend'] = dataframe[f'mgm_trend_{self.core_trend_timeframe}']
-            del dataframe[f'date_{self.core_trend_timeframe}']
-            del dataframe[f'ht_trendmode_{self.core_trend_timeframe}']
-            del dataframe[f'sar_{self.core_trend_timeframe}']
-            del dataframe[f'trend_{self.core_trend_timeframe}']
-            del dataframe[f'mgm_trend_{self.core_trend_timeframe}']
+            skip_columns = [f'{s}_{self.core_trend_timeframe}' for s in
+                            ['date', 'open', 'high', 'low', 'close', 'volume']]
+            dataframe.rename(columns=lambda s: s.replace('_{}'.format(self.core_trend_timeframe),
+                                                         '') if (s not in skip_columns) else s, inplace=True)
 
             # Just populate indicators.
             dataframe = self.do_populate_indicators(dataframe, metadata)

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -496,6 +496,9 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
 
             # Populate indicators at a larger timeframe
             informative = self.do_populate_indicators(informative.copy(), metadata)
+            # Drop unused columns to keep the dataframe lightweight
+            drop_columns = ['open', 'high', 'low', 'close', 'volume', f'date_{self.core_trend_timeframe}']
+            informative.drop(drop_columns, inplace=True, axis=1)
             # Merge indicators back in with, filling in missing values.
             dataframe = merge_informative_pair(dataframe, informative, self.timeframe,
                                                self.informative_timeframe, ffill=True)
@@ -505,6 +508,7 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
                             ['date', 'open', 'high', 'low', 'close', 'volume']]
             dataframe.rename(columns=lambda s: s.replace('_{}'.format(self.informative_timeframe),
                                                          '') if (s not in skip_columns) else s, inplace=True)
+            dataframe.drop([f'date_{self.informative_timeframe}'], inplace=True, axis=1)
 
         # Compute indicator data normally during Dry & Live Running or when not using TimeFrame-Zoom
         else:
@@ -519,6 +523,7 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
                             ['date', 'open', 'high', 'low', 'close', 'volume']]
             dataframe.rename(columns=lambda s: s.replace('_{}'.format(self.core_trend_timeframe),
                                                          '') if (s not in skip_columns) else s, inplace=True)
+            dataframe.drop([f'date_{self.core_trend_timeframe}'], inplace=True, axis=1)
 
             # Just populate indicators.
             dataframe = self.do_populate_indicators(dataframe, metadata)


### PR DESCRIPTION
- Add new 'trend_timeframe' in mgm-config.json to setting timeframe to detect core trend, if not set then using default timeframe

# TODO: 
- Didn't found any documentation about HT_TRENDMODE required startup candles number, so currently setting it to 200. This should to optimize incase of using long core trend timeframe like 1d might cause the bot loading candle pretty slow
- Using better logic to merge core_trend column to informative and main dataframe, because I'm quite new on python so don't know a good way to implement it yet, currently using manual rename and delete