### PR TITLE
🐞 BugFix - New `timeframes` config section

### DIFF
--- a/user_data/mgm_tools/ExportCsvResults.py
+++ b/user_data/mgm_tools/ExportCsvResults.py
@@ -81,8 +81,8 @@ def ExportCsvResults(config_file, input_file, output_file):
     # results_df['balance_max'] = epochs['results_metrics.csum_max'].apply(lambda x: round(x,2))
     results_df['pairlist'] = epochs['results_metrics.pairlist']
     results_df['max_open_trades_setting'] = epochs['results_metrics.max_open_trades_setting']
-    results_df['timeframe'] = mgm_config['timeframe']
-    results_df['backtest_timeframe'] = mgm_config['backtest_timeframe']
+    results_df['timeframe'] = mgm_config['timeframes']['timeframe']
+    results_df['backtest_timeframe'] = mgm_config['timeframes']['backtest_timeframe']
     results_df['timerange'] = epochs['results_metrics.timerange']
     results_df['backtest_start'] = epochs['results_metrics.backtest_start']
     results_df['backtest_end'] = epochs['results_metrics.backtest_end']

--- a/user_data/mgm_tools/mgm_hurry/MoniGoManiCli.py
+++ b/user_data/mgm_tools/mgm_hurry/MoniGoManiCli.py
@@ -354,7 +354,7 @@ class MoniGoManiCli(object):
         # Calculate the amount of days to add to the timerange based on the startup candle count & candle size
         mgm_config_files = self.monigomani_config.load_config_files()
         timeframe_minutes = self.timeframe_to_minutes(
-            mgm_config_files['mgm-config']['monigomani_settings']['timeframe'])
+            mgm_config_files['mgm-config']['monigomani_settings']['timeframes']['timeframe'])
         startup_candle_count = mgm_config_files['mgm-config']['monigomani_settings']['startup_candle_count']
         extra_days = ceil((timeframe_minutes * startup_candle_count) / (60 * 24))
 

--- a/user_data/strategies/MasterMoniGoManiHyperStrategy.py
+++ b/user_data/strategies/MasterMoniGoManiHyperStrategy.py
@@ -97,9 +97,9 @@ class MasterMoniGoManiHyperStrategy(IStrategy, ABC):
 
     # Apply the loaded MoniGoMani Settings
     try:
-        backtest_timeframe = mgm_config["timeframes"]['backtest_timeframe']
-        core_trend_timeframe_multiplier = mgm_config["timeframes"]['core_trend_timeframe_multiplier']
-        timeframe = mgm_config["timeframes"]['timeframe']
+        backtest_timeframe = mgm_config['timeframes']['backtest_timeframe']
+        core_trend_timeframe_multiplier = mgm_config['timeframes']['core_trend_timeframe_multiplier']
+        timeframe = mgm_config['timeframes']['timeframe']
         startup_candle_count = mgm_config['startup_candle_count']
         precision = mgm_config['precision']
         min_weighted_signal_value = mgm_config['weighted_signal_spaces']['min_weighted_signal_value']


### PR DESCRIPTION
- Fix bug `mgm-hurry download_candle_data` & `mgm-hurry export_csv` not using new `timeframes` config format
- Convert `"timeframes"` to `'timeframes'` single quote :stuck_out_tongue: 