### PR TITLE
🐞 BugFix - Prevent `self.freqtrade_binary` value from being smashed.

### DIFF
--- a/user_data/mgm_tools/mgm_hurry/FreqtradeCli.py
+++ b/user_data/mgm_tools/mgm_hurry/FreqtradeCli.py
@@ -88,7 +88,8 @@ class FreqtradeCli:
                                                  '"mgm-hurry install_freqtrade" before attempting to go further!'))
             return False
 
-        self.freqtrade_binary = self._get_freqtrade_binary_path(self.basedir, self.install_type)
+        if self.freqtrade_binary is None:
+            self.freqtrade_binary = self._get_freqtrade_binary_path(self.basedir, self.install_type)
 
         self.cli_logger.debug(f'👉 Freqtrade binary: `{self.freqtrade_binary}`')
 


### PR DESCRIPTION
## Main Issue
Since when the FreqtradeCLI class is initialized, the value of `self.freqtrade_binary` either set to the value from the config file, or `None`, there is no need to set the value again after it's already been set. 

This created an issue when `mgm-hurry up` would read a different value for `self.freqtrade_binary` than various other `mgm-hurry` subcommands.

Example:
![image](https://user-images.githubusercontent.com/2390633/147376985-ff03e279-f310-416b-a4ac-f30dcc7173b3.png)


### Misc
This is the result of my spam in the Discord lol, hopefully this is at least helpful. 

