### PR TITLE
🐞 BugFix - Change `source` to `.` for POSIX compliance

### DIFF
--- a/.hurry
+++ b/.hurry
@@ -1,7 +1,7 @@
 config:
   username: MoniGoMani Community
   exchange: binance
-  ft_binary: source ./.env/bin/activate; freqtrade
+  ft_binary: . ./.env/bin/activate; freqtrade
   hyperopt:
     epochs: 1000
     loss: MGM_WinRatioAndProfitRatioHyperOptLoss

--- a/mgm-hurry
+++ b/mgm-hurry
@@ -450,7 +450,7 @@ class MGMHurry:
 
         """
         if answers.get('install_type') == 'source':
-            ft_binary = f'source {self.basedir}/.env/bin/activate; freqtrade'
+            ft_binary = f'. {self.basedir}/.env/bin/activate; freqtrade'
         else:
             ft_binary = 'docker-compose run --rm freqtrade'
         """
@@ -458,7 +458,7 @@ class MGMHurry:
             'config': {
                 'username': answers.get('username'),
                 'install_type': 'source',  # answers.get('install_type'),
-                'ft_binary': f'source {self.basedir}/.env/bin/activate; freqtrade',  # ft_binary,
+                'ft_binary': f'. {self.basedir}/.env/bin/activate; freqtrade',  # ft_binary,
                 'timerange': answers.get('timerange'),
                 'exchange': exchange or 'none',
                 'hyperopt': {

--- a/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
+++ b/user_data/mgm_tools/Freqtrade-Download-Pairs.sh
@@ -78,7 +78,7 @@ fi
 
 # switch to freqtrade venv
 cd ${FQT_DIR};
-source .env/bin/activate ; 
+. .env/bin/activate ; 
 
 # loop through exchanges
 for EXCHANGE in ${EXCHANGES[@]}

--- a/user_data/mgm_tools/mgm_hurry/FreqtradeCli.py
+++ b/user_data/mgm_tools/mgm_hurry/FreqtradeCli.py
@@ -328,7 +328,7 @@ class FreqtradeCli:
         freqtrade_binary = 'docker-compose run --rm freqtrade'
 
         if install_type == 'source':
-            freqtrade_binary = f'source {basedir}/.env/bin/activate; freqtrade'
+            freqtrade_binary = f'. {basedir}/.env/bin/activate; freqtrade'
 
         return freqtrade_binary
 


### PR DESCRIPTION
## Issue
Since `subprocess` uses `/bin/sh` by default, it does not contain the shell builtin command `source`. This command only exists in `bash` or `zsh`.

To replicate this functionality, `.` can be used in its place for all POSIX compliant shells. An example error can be seen below prior to this change:
![image](https://user-images.githubusercontent.com/2390633/147420120-95845fbe-3364-4eb3-a852-1ba0189b429e.png)

sources: https://stackoverflow.com/questions/4732200/replacement-for-source-in-sh