### PR TITLE
⚡️ Notify the user that previous HyperOpt output exists

### DIFF
--- a/mgm-hurry
+++ b/mgm-hurry
@@ -688,6 +688,7 @@ class MGMHurry:
                 (strategy == 'MoniGoManiHyperStrategy') and (
                 os.path.isfile(self.monigomani_config.get_config_filepath('mgm-config-hyperopt')) is True)):
             initial_run = False
+            self.logger.info("🍺 Previous HyperOpt run found! This HyperOpt run will be refining on the already existing HyperOpt output.")
 
         self.logger.info(Color.title('👉 Starting HyperOpt run. Keep calm while your computer burns 🔥'))
 

--- a/mgm-hurry
+++ b/mgm-hurry
@@ -688,7 +688,7 @@ class MGMHurry:
                 (strategy == 'MoniGoManiHyperStrategy') and (
                 os.path.isfile(self.monigomani_config.get_config_filepath('mgm-config-hyperopt')) is True)):
             initial_run = False
-            self.logger.info("🍺 Previous HyperOpt run found! This HyperOpt run will be refining on the already existing HyperOpt output.")
+            self.logger.info('🍺 Previous HyperOpt run found! This HyperOpt run will be refining on the already existing HyperOpt output.')
 
         self.logger.info(Color.title('👉 Starting HyperOpt run. Keep calm while your computer burns 🔥'))
 


### PR DESCRIPTION
## Main issue
This would just be a nice-to-have, up to you if you would like to actually print this out. It gives me some peace of mind knowing that previous output was found when running `mgm-hurry hyperopt`, as long as I intend it to be that way 😛  