### PR TITLE
✨ Added `docker` build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ test-results*.xml
 .env/
 build_helpers/
 config_examples/
-docker/
+docker/*
 !docker/Dockerfile.MoniGoMani
 docs/
 freqtrade/

--- a/.hurry
+++ b/.hurry
@@ -14,3 +14,4 @@ config:
     mgm-config-hyperopt: mgm-config-hyperopt.json
     mgm-config-private: mgm-config-private.json
   timerange: 20210501-20210616
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+---
+version: '3'
+services:
+  freqtrade-mgm:
+    # image: freqtradeorg/freqtrade:stable
+    # image: freqtradeorg/freqtrade:develop
+    # Use plotting image
+    # image: freqtradeorg/freqtrade:develop_plot
+    # Build step - only needed when additional dependencies are needed
+    build:
+       context: "."
+       dockerfile: "./docker/Dockerfile.MoniGoMani"
+    restart: unless-stopped
+    container_name: freqtrade-mgm
+    volumes:
+      - "./user_data:/freqtrade/user_data"
+
+    # Expose api on port 8080 (localhost only)
+    # Please read the https://www.freqtrade.io/en/latest/rest-api/ documentation
+    # before enabling this.
+    ports:
+       - 8080:8080
+    # Default command used when running `docker compose up`
+    command: >
+      trade
+      --logfile /freqtrade/user_data/logs/freqtrade.log
+      --config /freqtrade/user_data/mgm-config.json
+      --config /freqtrade/user_data/mgm-config-private.json

--- a/docker/Dockerfile.MoniGoMani
+++ b/docker/Dockerfile.MoniGoMani
@@ -1,0 +1,30 @@
+FROM freqtradeorg/freqtrade:latest as base
+
+# System prerequisites
+USER root
+RUN  apt-get update \
+  && apt-get -y install build-essential libblas3 liblapack3 liblapack-dev libblas-dev libatlas-base-dev libxml2-dev libxslt-dev \
+                        libssl-dev python3-dev gcc gfortran g++ git python3-venv libfreetype6-dev expect libffi-dev cmake \
+  && apt-get clean
+# build latest libgit2 v1.4.x for pygit2
+RUN git clone --depth=1 -b v1.4.2 https://github.com/libgit2/libgit2.git ~/libgit2_src
+RUN cd ~/libgit2_src && cmake . -DBUILD_CLAR=OFF -DCMAKE_BUILD_TYPE=Release -DEMBED_SSH_PATH=~/libssh2_src -DCMAKE_INSTALL_PREFIX=~/libgit2
+RUN cd ~/libgit2_src && cmake --build . --target install
+RUN cp -r ~/libgit2/* /usr/bin
+RUN cp -r ~/libgit2/* /usr/local
+
+# MGM prerequisites
+USER ftuser
+RUN pip3 install --upgrade pip
+RUN pip3 install --user --no-cache-dir finta scipy pyaml scikit-optimize fire matplotlib quantstats art inquirerpy distro pygit2 yaspin logger discord_webhook
+
+# Install MGM
+RUN git clone https://github.com/Rikj000/MoniGoMani.git
+RUN cp -r MoniGoMani/* . && rm -rf MoniGoMani/
+RUN pip3 install --user --no-cache-dir pyaml
+COPY --chown=ftuser:ftuser .hurry /freqtrade
+#RUN ./mgm-hurry setup
+
+ENTRYPOINT ["freqtrade"]
+# Default to trade mode
+CMD [ "trade" ]

--- a/docker/Dockerfile.MoniGoMani
+++ b/docker/Dockerfile.MoniGoMani
@@ -21,7 +21,6 @@ RUN pip3 install --user --no-cache-dir finta scipy pyaml scikit-optimize fire ma
 # Install MGM
 RUN git clone https://github.com/Rikj000/MoniGoMani.git
 RUN cp -r MoniGoMani/* . && rm -rf MoniGoMani/
-RUN pip3 install --user --no-cache-dir pyaml
 COPY --chown=ftuser:ftuser .hurry /freqtrade
 #RUN ./mgm-hurry setup
 

--- a/docker/Dockerfile.MoniGoMani
+++ b/docker/Dockerfile.MoniGoMani
@@ -22,7 +22,6 @@ RUN pip3 install --user --no-cache-dir finta scipy pyaml scikit-optimize fire ma
 RUN git clone https://github.com/Rikj000/MoniGoMani.git
 RUN cp -r MoniGoMani/* . && rm -rf MoniGoMani/
 COPY --chown=ftuser:ftuser .hurry /freqtrade
-#RUN ./mgm-hurry setup
 
 ENTRYPOINT ["freqtrade"]
 # Default to trade mode

--- a/pyenv.bashrc
+++ b/pyenv.bashrc
@@ -1,0 +1,5 @@
+
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+


### PR DESCRIPTION
it took me quite some time to get all dependencies for freqtrade and MGM working but at least here is a base to start with.
you need to run it from inside the folder where you cloned the MGM development branch.

be careful : building the docker images takes quite some time (especially on Raspberry Pi), resulting in a 1.6G image